### PR TITLE
Prevent data volume deletion

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -46,6 +46,8 @@ const (
 	AnnKubevirtValidations = "vm.kubevirt.io/validations"
 	// PVC annotation containing the name of the importer pod.
 	AnnImporterPodName = "cdi.kubevirt.io/storage.import.importPodName"
+	// DV deletion on completion
+	AnnDeleteAfterCompletion = "cdi.kubevirt.io/storage.deleteAfterCompletion"
 )
 
 // Labels
@@ -669,6 +671,9 @@ func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap
 			annotations[AnnDefaultNetwork] = path.Join(
 				r.Plan.Spec.TransferNetwork.Namespace, r.Plan.Spec.TransferNetwork.Name)
 		}
+		// Do not delete the DV when the import completes as we check the DV to get the current
+		// disk transfer status.
+		annotations[AnnDeleteAfterCompletion] = "false"
 		dv := cdi.DataVolume{
 			ObjectMeta: meta.ObjectMeta{
 				Namespace:   r.Plan.Spec.TargetNamespace,


### PR DESCRIPTION
With the new CDI change, the data volumes being deleted when the import completes. However, the controller lookup for the data volumes in order to know when the disk transfer is complete and and progress with the migration flow. In order to prevent it, an annotation is added to the data volumes.